### PR TITLE
[Feat] 시작 안한 챌린지 목록 조회 API

### DIFF
--- a/src/main/java/igoMoney/BE/common/exception/ErrorCode.java
+++ b/src/main/java/igoMoney/BE/common/exception/ErrorCode.java
@@ -15,10 +15,10 @@ public enum ErrorCode {
     // Token 예외
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
-    ID_TOKEN_INVALID_1(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다."),
-    ID_TOKEN_INVALID_2(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다."),
-    ID_TOKEN_INVALID_3(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다."),
-    ID_TOKEN_INVALID_4(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다."),
+    ID_TOKEN_INVALID_1(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다.(토큰 서명 검증 or 구조 문제)"),
+    ID_TOKEN_INVALID_2(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다.(토큰 디코딩 문제)"),
+    ID_TOKEN_INVALID_3(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다.(서명 검증 결과)"),
+    ID_TOKEN_INVALID_4(HttpStatus.UNAUTHORIZED, "ID토큰이 유효하지 않습니다.(서명 검증 결과)"),
     ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "ID토큰이 만료되었습니다."),
     AUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "Authorization Code가 유효하지 않습니다."),
 

--- a/src/main/java/igoMoney/BE/controller/ChallengeController.java
+++ b/src/main/java/igoMoney/BE/controller/ChallengeController.java
@@ -1,0 +1,32 @@
+package igoMoney.BE.controller;
+
+import igoMoney.BE.dto.response.ChallengeResponse;
+import igoMoney.BE.service.ChallengeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("challenges")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    // 시작 안 한 챌린지 목록 조회
+    @GetMapping("notstarted")
+    public ResponseEntity<List<ChallengeResponse>> getNotStartedChallengeList() {
+
+        List<ChallengeResponse> response = challengeService.getNotStartedChallengeList();
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+}

--- a/src/main/java/igoMoney/BE/domain/Challenge.java
+++ b/src/main/java/igoMoney/BE/domain/Challenge.java
@@ -1,0 +1,33 @@
+package igoMoney.BE.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Challenge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_id")
+    private Long id;
+
+    private Long leaderId;
+    private Long winnerId;
+    private Long recordId;
+
+    private String title;
+    private String content;
+    private Integer targetAmount;
+    private LocalDate startDate;
+    private Integer term;
+    private LocalDate endDate;
+}

--- a/src/main/java/igoMoney/BE/domain/User.java
+++ b/src/main/java/igoMoney/BE/domain/User.java
@@ -34,10 +34,14 @@ public class User extends BaseEntity {
     private String role; // ROLE_USER 혹은 ROLE_ADMIN
 
     // 추가 정보
+    @Builder.Default
     private Boolean inChallenge=false;
-    private Integer challengeCount;
-    private Integer badgeCount;
-    private Integer winCount;
+    @Builder.Default
+    private Integer challengeCount=0;
+    @Builder.Default
+    private Integer badgeCount=0;
+    @Builder.Default
+    private Integer winCount=0;
 
     public void updateUser(UserUpdateRequest request) {
         this.nickname = request.getNickname();

--- a/src/main/java/igoMoney/BE/dto/response/ChallengeResponse.java
+++ b/src/main/java/igoMoney/BE/dto/response/ChallengeResponse.java
@@ -1,0 +1,25 @@
+package igoMoney.BE.dto.response;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeResponse {
+
+    private Long id;
+    private Long leaderId;
+    private Long winnerId;
+    private Long recordId;
+    private String title;
+    private String content;
+    private Integer targetAmount;
+    private LocalDate startDate;
+    private Integer term;
+    private LocalDate endDate;
+}

--- a/src/main/java/igoMoney/BE/repository/ChallengeRepository.java
+++ b/src/main/java/igoMoney/BE/repository/ChallengeRepository.java
@@ -1,0 +1,12 @@
+package igoMoney.BE.repository;
+
+import igoMoney.BE.domain.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    List<Challenge> findAllByStartDateIsNull();
+}

--- a/src/main/java/igoMoney/BE/service/ChallengeService.java
+++ b/src/main/java/igoMoney/BE/service/ChallengeService.java
@@ -1,0 +1,40 @@
+package igoMoney.BE.service;
+
+import igoMoney.BE.domain.Challenge;
+import igoMoney.BE.dto.response.ChallengeResponse;
+import igoMoney.BE.repository.ChallengeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+
+    // 시작 안 한 챌린지 목록 조회
+    public List<ChallengeResponse> getNotStartedChallengeList() {
+
+        List<ChallengeResponse> responseList = new ArrayList<>();
+        List<Challenge> challengeList = challengeRepository.findAllByStartDateIsNull();
+        for (Challenge challenge: challengeList){
+            ChallengeResponse challengeResponse = ChallengeResponse.builder()
+                    .id(challenge.getId())
+                    .leaderId(challenge.getLeaderId())
+                    .title(challenge.getTitle())
+                    .content(challenge.getContent())
+                    .targetAmount(challenge.getTargetAmount())
+                    .build();
+            responseList.add(challengeResponse);
+        }
+
+        return responseList;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- close #7
##  작업 내용
- 시작 안한 챌린지 목록 조회 API 구현
- 챌린지 엔티티 관련 폴더링
- DB :  utf8mb4 적용
##  기타
-