### PR TITLE
[Feat] 시작안한 챌린지 조회 - 주제 검색 추가

### DIFF
--- a/src/main/java/igoMoney/BE/common/config/JwtExceptionFilter.java
+++ b/src/main/java/igoMoney/BE/common/config/JwtExceptionFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,6 +21,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         try {
             chain.doFilter(req, res); // go to 'JwtAuthFilter'
         } catch (JwtException ex) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, res, ex);
+        } catch (UsernameNotFoundException ex){
             setErrorResponse(HttpStatus.UNAUTHORIZED, res, ex);
         }
     }

--- a/src/main/java/igoMoney/BE/controller/ChallengeController.java
+++ b/src/main/java/igoMoney/BE/controller/ChallengeController.java
@@ -26,9 +26,10 @@ public class ChallengeController {
     @GetMapping("notstarted")
     public ResponseEntity<List<ChallengeResponse>> getNotStartedChallengeList(
             @RequestParam(value="lastId", required=false, defaultValue="10") Long lastId,
-            @RequestParam(value="pageSize", required=false, defaultValue="10") int pageSize) {
+            @RequestParam(value="pageSize", required=false, defaultValue="10") int pageSize,
+            @RequestParam(value="categoryId", required=false, defaultValue="-1") Integer categoryId) {
 
-        List<ChallengeResponse> response = challengeService.getNotStartedChallengeList(lastId, pageSize);
+        List<ChallengeResponse> response = challengeService.getNotStartedChallengeList(lastId, pageSize, categoryId);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/igoMoney/BE/repository/ChallengeCustomRepository.java
+++ b/src/main/java/igoMoney/BE/repository/ChallengeCustomRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface ChallengeCustomRepository {
     List<Challenge> findAllNotStarted(int pageSize, Long lastId, LocalDate date);
+    List<Challenge> findAllNotStartedByCategory(int pageSize, Long lastId, LocalDate date, Integer categoryId);
 }

--- a/src/main/java/igoMoney/BE/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/igoMoney/BE/repository/ChallengeCustomRepositoryImpl.java
@@ -20,8 +20,19 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
     @Override
     public List<Challenge> findAllNotStarted(int pageSize, Long lastId, LocalDate date){
         return jpaQueryFactory.selectFrom(challenge)
-                .where(ltChallengeId(lastId),
-                        challenge.startDate.gt(date))
+                .where(challenge.startDate.gt(date),
+                        ltChallengeId(lastId))
+                .orderBy(challenge.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    @Override
+    public List<Challenge> findAllNotStartedByCategory(int pageSize, Long lastId, LocalDate date, Integer categoryId){
+        return jpaQueryFactory.selectFrom(challenge)
+                .where( challenge.categoryId.eq(categoryId),
+                        challenge.startDate.gt(date),
+                        ltChallengeId(lastId))
                 .orderBy(challenge.id.desc())
                 .limit(pageSize)
                 .fetch();

--- a/src/main/java/igoMoney/BE/service/ChallengeService.java
+++ b/src/main/java/igoMoney/BE/service/ChallengeService.java
@@ -36,10 +36,15 @@ public class ChallengeService {
     DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("MM월 dd일");
 
     // 시작 안 한 챌린지 목록 조회
-    public List<ChallengeResponse> getNotStartedChallengeList(Long lastId, int pageSize) {
+    public List<ChallengeResponse> getNotStartedChallengeList(Long lastId, int pageSize, Integer categoryId) {
 
         List<ChallengeResponse> responseList = new ArrayList<>();
-        List<Challenge> challengeList = challengeRepository.findAllNotStarted(pageSize, lastId, LocalDate.now());
+        List<Challenge> challengeList;
+        if (categoryId == -1){
+            challengeList = challengeRepository.findAllNotStarted(pageSize, lastId, LocalDate.now());
+        } else{
+            challengeList = challengeRepository.findAllNotStartedByCategory(pageSize, lastId, LocalDate.now(), categoryId);
+        }
         for (Challenge challenge: challengeList){
             ChallengeResponse challengeResponse = ChallengeResponse.builder()
                     .id(challenge.getId())

--- a/src/test/java/igoMoney/BE/service/ChallengeServiceTest.java
+++ b/src/test/java/igoMoney/BE/service/ChallengeServiceTest.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -33,24 +34,25 @@ public class ChallengeServiceTest {
                     .content("__")
                     .targetAmount(10000)
                     .startDate(LocalDate.now().plusDays(2))
+                    .categoryId(1)
                     .build());
         }
 
         //when
         List<Challenge> challenges = challengeRepository.findAllNotStarted(10, null, LocalDate.now()); // pageNo는 0부터 시작이라 1이면 두번째 페이지 조회
+        List<Challenge> challenges2 = challengeRepository.findAllNotStarted(10, 21L, LocalDate.now()); // DESC. 20~11
+        List<Challenge> challenges3 = challengeRepository.findAllNotStartedByCategory(10, 21L, LocalDate.now(), 2);
 
         //then
         assertEquals(challenges.size(),10);
         assertEquals(30,(long) challenges.get(0).getId());
         assertEquals(21, (long) challenges.get(9).getId());
 
-        // [NoOffset 2번째 페이지]
-//        //when
-//        List<Challenge> challenges = challengeRepository.findAllNotStarted(10, 21L); // DESC. 20~11
-//
-//        //then
-//        assertThat(challenges).hasSize(10);
-//        assertThat(challenges.get(0).getId()).isEqualTo(20);
-//        assertThat(challenges.get(9).getId()).isEqualTo(11);
+        assertThat(challenges2).hasSize(10);
+        assertThat(challenges2.get(0).getId()).isEqualTo(20);
+        assertThat(challenges2.get(9).getId()).isEqualTo(11);
+
+        assertThat(challenges3).hasSize(0);
+
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #72
##  작업 내용
- 시작안한 챌린지 조회 API에  주제 검색 가능하도록 변경한다
##  기타
-