### PR TITLE
[Chore] 시작안한 챌린지 조회 API - targetAmount 필터링 추가

### DIFF
--- a/src/main/java/igoMoney/BE/controller/ChallengeController.java
+++ b/src/main/java/igoMoney/BE/controller/ChallengeController.java
@@ -27,9 +27,10 @@ public class ChallengeController {
     public ResponseEntity<List<ChallengeResponse>> getNotStartedChallengeList(
             @RequestParam(value="lastId", required=false, defaultValue="10") Long lastId,
             @RequestParam(value="pageSize", required=false, defaultValue="10") int pageSize,
-            @RequestParam(value="categoryId", required=false, defaultValue="-1") Integer categoryId) {
+            @RequestParam(value="categoryId", required=false, defaultValue="-1") Integer categoryId,
+            @RequestParam(value="targetAmount", required=false, defaultValue="-1") Integer targetAmount) {
 
-        List<ChallengeResponse> response = challengeService.getNotStartedChallengeList(lastId, pageSize, categoryId);
+        List<ChallengeResponse> response = challengeService.getNotStartedChallengeList(lastId, pageSize, categoryId, targetAmount);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/igoMoney/BE/repository/ChallengeCustomRepository.java
+++ b/src/main/java/igoMoney/BE/repository/ChallengeCustomRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface ChallengeCustomRepository {
     List<Challenge> findAllNotStarted(int pageSize, Long lastId, LocalDate date);
     List<Challenge> findAllNotStartedByCategory(int pageSize, Long lastId, LocalDate date, Integer categoryId);
+    List<Challenge> findAllNotStartedByTargetAmount(int pageSize, Long lastId, LocalDate date, Integer targetAmount);
+    List<Challenge> findAllNotStartedByCategoryAndTargetAmount(int pageSize, Long lastId, LocalDate date, Integer categoryId, Integer targetAmount);
 }

--- a/src/main/java/igoMoney/BE/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/igoMoney/BE/repository/ChallengeCustomRepositoryImpl.java
@@ -38,6 +38,29 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository 
                 .fetch();
     }
 
+    @Override
+    public List<Challenge> findAllNotStartedByTargetAmount(int pageSize, Long lastId, LocalDate date, Integer targetAmount){
+        return jpaQueryFactory.selectFrom(challenge)
+                .where( challenge.targetAmount.eq(targetAmount),
+                        challenge.startDate.gt(date),
+                        ltChallengeId(lastId))
+                .orderBy(challenge.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    @Override
+    public List<Challenge> findAllNotStartedByCategoryAndTargetAmount(int pageSize, Long lastId, LocalDate date, Integer categoryId, Integer targetAmount){
+        return jpaQueryFactory.selectFrom(challenge)
+                .where( challenge.categoryId.eq(categoryId),
+                        challenge.targetAmount.eq(targetAmount),
+                        challenge.startDate.gt(date),
+                        ltChallengeId(lastId))
+                .orderBy(challenge.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
     private BooleanExpression ltChallengeId(Long lastId) {
 
         if (lastId == null) {

--- a/src/main/java/igoMoney/BE/service/ChallengeService.java
+++ b/src/main/java/igoMoney/BE/service/ChallengeService.java
@@ -36,14 +36,23 @@ public class ChallengeService {
     DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("MM월 dd일");
 
     // 시작 안 한 챌린지 목록 조회
-    public List<ChallengeResponse> getNotStartedChallengeList(Long lastId, int pageSize, Integer categoryId) {
+    public List<ChallengeResponse> getNotStartedChallengeList(Long lastId, int pageSize, Integer categoryId, Integer targetAmount) {
 
         List<ChallengeResponse> responseList = new ArrayList<>();
         List<Challenge> challengeList;
         if (categoryId == -1){
-            challengeList = challengeRepository.findAllNotStarted(pageSize, lastId, LocalDate.now());
+            if (targetAmount == -1){
+                challengeList = challengeRepository.findAllNotStarted(pageSize, lastId, LocalDate.now());
+            } else {
+                challengeList = challengeRepository.findAllNotStartedByTargetAmount(pageSize, lastId, LocalDate.now(), targetAmount);
+            }
+
         } else{
-            challengeList = challengeRepository.findAllNotStartedByCategory(pageSize, lastId, LocalDate.now(), categoryId);
+            if (targetAmount == -1) {
+                challengeList = challengeRepository.findAllNotStartedByCategory(pageSize, lastId, LocalDate.now(), categoryId);
+            } else {
+                challengeList = challengeRepository.findAllNotStartedByCategoryAndTargetAmount(pageSize, lastId, LocalDate.now(), categoryId, targetAmount);
+            }
         }
         for (Challenge challenge: challengeList){
             ChallengeResponse challengeResponse = ChallengeResponse.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     show-sql: false
     generate-ddl: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📌 관련 이슈
- close #96
##  작업 내용
- 시작안한 챌린지 조회 API 에 targetAmount 필터링 추가
- ChallengeController에 targetAmount 파라미터 추가하고 디폴트값 설정.
- targetAmount 값이 디폴트값인가에 따라 검색 로직 변경하도록 repository 조회 방식 변경
##  기타
-