### PR TITLE
[Fix] emoji 때문에 글 길이 제한은 프론트로 넘김

### DIFF
--- a/src/main/java/igoMoney/BE/dto/request/ChallengeCreateRequest.java
+++ b/src/main/java/igoMoney/BE/dto/request/ChallengeCreateRequest.java
@@ -2,8 +2,6 @@ package igoMoney.BE.dto.request;
 
 import lombok.*;
 
-import jakarta.validation.constraints.Size;
-
 import java.time.LocalDate;
 
 @Getter
@@ -14,9 +12,7 @@ import java.time.LocalDate;
 public class ChallengeCreateRequest {
 
     private Long userId;
-    @Size(min=5, max=15)
     private String title;
-    @Size(max=300)
     private String content;
     private Integer targetAmount;
     private Integer categoryId;

--- a/src/main/java/igoMoney/BE/dto/request/NicknameChangeRequest.java
+++ b/src/main/java/igoMoney/BE/dto/request/NicknameChangeRequest.java
@@ -2,7 +2,6 @@ package igoMoney.BE.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 @Getter
@@ -15,6 +14,5 @@ public class NicknameChangeRequest {
     @NotNull
     private Long userId;
     @NotBlank(message = "닉네임은 공백일 수 없습니다.")
-    @Pattern(regexp = "^[^\n\t\r\f]{3,8}$", message = "닉네임은 \\t, \\r, \\n, \\f 제외 최소3자 최대 8자여야 합니다.")
     private String nickname;
 }

--- a/src/main/java/igoMoney/BE/dto/request/RecordSaveRequest.java
+++ b/src/main/java/igoMoney/BE/dto/request/RecordSaveRequest.java
@@ -1,7 +1,6 @@
 package igoMoney.BE.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,9 +17,7 @@ public class RecordSaveRequest {
     private Long challengeId;
     @NotNull
     private Long userId;
-    @NotNull @Size(min=5, max=15)
     private String title;
-    @Size(max=300)
     private String content;
     private Integer cost;
     private List<MultipartFile> image;

--- a/src/main/java/igoMoney/BE/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/igoMoney/BE/dto/request/RecordUpdateRequest.java
@@ -1,7 +1,6 @@
 package igoMoney.BE.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,9 +15,8 @@ public class RecordUpdateRequest {
 
     @NotNull
     private Long recordId;
-    @NotNull @Size(min=5, max=15)
+    @NotNull
     private String title;
-    @Size(max=300)
     private String content;
     private Integer cost;
     private List<MultipartFile> image;


### PR DESCRIPTION
## 📌 관련 이슈
- close #100
##  작업 내용
- 닉네임, 챌린지 및 record의 title, content 길이 제한 및 regex 삭제
##  기타
-